### PR TITLE
Preliminary K052001 (KONAMI-2) core.

### DIFF
--- a/K051316/k051316.cpp
+++ b/K051316/k051316.cpp
@@ -28,8 +28,6 @@ namespace beekonami
 
     void K051316::tickInternal(bool clk)
     {
-	static bool prev_clk = false;
-
 	if (prev_clk && !clk)
 	{
 	    m12_delay = current_pins.pin_m12;
@@ -37,10 +35,10 @@ namespace beekonami
 
 	tickWrite();
 	tickClocks();
-	tickXCounter();
-	tickYCounter();
 	tickRAM();
 	tickAddr();
+	tickXCounter();
+	tickYCounter();
 
 	prev_ram_l_we = ram_l_we;
 	prev_ram_r_we = ram_r_we;
@@ -91,7 +89,6 @@ namespace beekonami
 
 	if (r31_q && !testbit(regE, 7))
 	{
-	    // TODO: Implement rendering
 	    int x_val = ((x_acc >> 15) & 0x1F);
 	    int y_val = ((y_acc >> 15) & 0x1F);
 	    ram_addr = ((y_val << 5) | x_val);
@@ -230,21 +227,6 @@ namespace beekonami
 
     void K051316::tickAddr()
     {
-	if (prev_ram_clk && !ram_clk)
-	{
-	    ram_reg = ((ram_l_dout << 8) | ram_r_dout);
-	}
-
-	if (!prev_r31 && r31_q)
-	{
-	    pre_reg = ram_reg;
-	}
-
-	if (prev_r31 && !r31_q)
-	{
-	    ram_data = ram_reg;
-	}
-
 	if (prev_m6 && !current_pins.pin_m6)
 	{
 	    int x_oblk = ((x_acc >> 20) & 0xF);
@@ -270,7 +252,22 @@ namespace beekonami
 	    x_reg = ((x_acc >> 11) & 0xF);
 	    y_reg = ((y_acc >> 11) & 0xF);
 
-	    render_addr = ((ram_reg << 8) | (yflip << 4) | xflip);
+	    render_addr = ((pre_reg << 8) | (yflip << 4) | xflip);
+	}
+
+	if (prev_ram_clk && !ram_clk)
+	{
+	    ram_reg = ((ram_l_dout << 8) | ram_r_dout);
+	}
+
+	if (!prev_r31 && r31_q)
+	{
+	    pre_reg = ram_reg;
+	}
+
+	if (prev_r31 && !r31_q)
+	{
+	    ram_data = ram_reg;
 	}
 
 

--- a/K051316/k051316.h
+++ b/K051316/k051316.h
@@ -62,6 +62,7 @@ namespace beekonami
 	    void tickRAM();
 	    void tickAddr();
 
+	    bool prev_clk = false;
 	    bool ram_clk = false;
 	    bool prev_ram_clk = false;
 

--- a/K052001/k052001.h
+++ b/K052001/k052001.h
@@ -1007,6 +1007,18 @@ namespace beekonami
 			setOverflow(false);
 		    }
 		    break;
+		    case Or8:
+		    {
+			alu8_res = (alu8_a | alu8_b);
+			setOverflow(false);
+		    }
+		    break;
+		    case Eor8:
+		    {
+			alu8_res = (alu8_a ^ alu8_b);
+			setOverflow(false);
+		    }
+		    break;
 		    default:
 		    {
 			cout << "Unrecognized ALU 8-bit opcode of " << hex << int(alu8_op) << endl;

--- a/K052001/k052001.h
+++ b/K052001/k052001.h
@@ -35,6 +35,8 @@ namespace beekonami
 	    LBraOffsetLow,
 	    Imm16Low,
 	    IndexedBase,
+	    ExtendedAddrLow,
+	    ExtendedDontCare,
 	    AluEA,
 	    DivZeroCheck,
 	    Divide,
@@ -87,6 +89,7 @@ namespace beekonami
 	enum K052001IndexMode
 	{
 	    ModeNone = 0,
+	    ModeExtended,
 	    ModeNoOffs,
 	};
 
@@ -395,7 +398,6 @@ namespace beekonami
 		fetchAddrMode(instr_hi, instr_lo);
 		fetchALU8(instr_hi, instr_lo);
 		fetchSpecialImm(instr_hi, instr_lo);
-		fetchRegA(instr_hi, instr_lo);
 		fetchStore8(instr);
 		fetchJump(instr);
 	    }
@@ -518,8 +520,17 @@ namespace beekonami
 		}
 	    }
 
+	    void fetchALU8(uint8_t instr)
+	    {
+		int instr_hi = (instr >> 4);
+		int instr_lo = (instr & 0xF);
+		fetchALU8(instr_hi, instr_lo);
+	    }
+
 	    void fetchALU8(int instr_hi, int instr_lo)
 	    {
+		fetchRegA(instr_hi, instr_lo);
+
 		is_alu8_wb = true;
 		switch (instr_hi)
 		{
@@ -940,6 +951,12 @@ namespace beekonami
 		uint8_t indexed = (instr & 0xF7);
 		switch (indexed)
 		{
+		    case 0x07:
+		    {
+			index_mode = ModeExtended;
+			index_reg = IdxRegNone;
+		    }
+		    break;
 		    case 0x26:
 		    case 0x36:
 		    case 0x46:

--- a/K052001/k052001.h
+++ b/K052001/k052001.h
@@ -60,9 +60,9 @@ namespace beekonami
 	    Sub8,
 	    Sbc8,
 	    And8,
-	    Bit8,
-	    Eor8,
 	    Or8,
+	    Eor8,
+	    Bit8,
 	    Cmp8,
 	};
 
@@ -999,6 +999,12 @@ namespace beekonami
 
 			uint32_t overflow_res = calcOverflow(alu8_a, alu8_b, alu8_res);
 			setOverflow(testbit(overflow_res, 7));
+		    }
+		    break;
+		    case And8:
+		    {
+			alu8_res = (alu8_a & alu8_b);
+			setOverflow(false);
 		    }
 		    break;
 		    default:


### PR DESCRIPTION
New features:

Add preliminary K052001 (KONAMI-2) core.
Use "pre_reg" variable for address output in K051316 (PSAC) core. This matches furrtek's schematics.